### PR TITLE
Bump cortex-m to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ maintenance = { status = "actively-maintained" }
 
 [dependencies]
 bare-metal = "0.2.5"
-cortex-m = "0.6.2"
+cortex-m = "0.7.0"
 cortex-m-rt = { version = "0.6.12", optional = true }
 vcell = "0.1.2"
 


### PR DESCRIPTION
The 0.7.0 release of cortex-m includes some updates for accessing the SAU, bump the version here as a dependency